### PR TITLE
remove violet blue from en word list

### DIFF
--- a/server/userTemp/languages/en.txt
+++ b/server/userTemp/languages/en.txt
@@ -340,7 +340,6 @@ urophilia
 vagina
 venus mound
 vibrator
-violet blue
 violet wand
 vorarephilia
 voyeur


### PR DESCRIPTION
it's a person's name, and not a vulgar phrase.
